### PR TITLE
feat: add eslint api v9 compatibility

### DIFF
--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -255,11 +255,15 @@ module.exports = {
             return null;
         }
 
-
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
         return {
             ExpressionStatement: function(node) {
                 var valid = !Checker.isDisallowed(node.expression)
-                    || isDirective(node, context.getAncestors())
+                    || isDirective(node,
+                        (sourceCode.getAncestors
+                            ? sourceCode.getAncestors(node)
+                            : context.getAncestors()
+                        ))
                     || isChaiExpectCall(node)
                     || isChaiShouldCall(node);
                 if (!valid) {


### PR DESCRIPTION
- closes https://github.com/ihordiachenko/eslint-plugin-chai-friendly/issues/32

## Issue

Running the following in this repo (currently based on [eslint@8.56.0](https://github.com/eslint/eslint/releases/tag/v8.56.0)):

```shell
npm ci
npm test
```

results in the deprecation warning:

> (node:29800) DeprecationWarning: "no-unused-expressions" rule is using `context.getAncestors()`, which is deprecated and will be removed in ESLint v9. Please use `sourceCode.getAncestors()` instead.

## Change

Use the information in the blog post [Preparing your custom rules for ESLint v9.0.0](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/) from Sep 26, 2023 from the section [context.getAncestors()](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getancestors()) to update the rule [lib/rules/no-unused-expressions.js](https://github.com/ihordiachenko/eslint-plugin-chai-friendly/blob/master/lib/rules/no-unused-expressions.js) so that it is compatible with ESLint `v9` and with earlier ESLint versions.

## Verification

### Deprecation

Confirm that deprecation is resolved by executing:

```shell
npm ci
npm test
```

Verify that no deprecation warning is output and that all tests pass (81 passing).

### Backwards compatibility

Install an earlier version of ESLint (`8.0.0`), before the replacement method `SourceCode#getAncestors(node)` was added, and confirm that tests continue to pass (81 passing).

```shell
npm install eslint@8.0.0
npm test
```
