### PR TITLE
feat: add `name` (for tooling)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ const plugin = {
 Object.assign(plugin.configs, {
     // Compatible with ESLint v9 flat configs
     recommendedFlat: {
+        name: 'chai-friendly/recommendedFlat',
         plugins: {
             'chai-friendly': plugin
         },


### PR DESCRIPTION
ESLint [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions) a name for flat configs.

Tools like https://github.com/eslint/config-inspector can use this to indicate the source of rules.

I did not add it to the older, non-flat config because it will err there.