### PR TITLE
Add support for ternary and short circuit options

### DIFF
--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -148,7 +148,8 @@ module.exports = {
             ClassExpression: alwaysTrue,
             ConditionalExpression(node) {
                 if (allowTernary) {
-                    return Checker.isDisallowed(node.consequent) || Checker.isDisallowed(node.alternate);
+                    return (Checker.isDisallowed(node.consequent) && !isChaiCall(node.consequent)) ||
+                           (Checker.isDisallowed(node.alternate) && !isChaiCall(node.alternate));
                 }
                 return true;
             },
@@ -163,7 +164,7 @@ module.exports = {
             },
             LogicalExpression(node) {
                 if (allowShortCircuit) {
-                    return Checker.isDisallowed(node.right);
+                    return Checker.isDisallowed(node.right) && !isChaiCall(node.right);
                 }
                 return true;
             },
@@ -198,16 +199,15 @@ module.exports = {
         /**
          * Determines whether or not a given node is a chai's expect statement.
          * e.g. expect(foo).to.eventually.be.true;
-         * @param {ASTNode} node - any node
+         * @param {ASTNode} expressionNode - expression node
          * @returns {boolean} whether the given node is a chai expectation
          */
-        function isChaiExpectCall(node) {
-            let expression = node.expression;
-            if (expression.type !== 'MemberExpression') {
+        function isChaiExpectCall(expressionNode) {
+            if (expressionNode.type !== 'MemberExpression') {
                 return false;
             }
 
-            return Boolean(findExpectCall(expression.object));
+            return Boolean(findExpectCall(expressionNode.object));
         }
 
         /**
@@ -239,19 +239,18 @@ module.exports = {
         /**
          * Determines whether or not a given node is a chai's should statement.
          * e.g. foo.should.eventually.be.true;
-         * @param {ASTNode} node - any node
+         * @param {ASTNode} expressionNode - expression node
          * @returns {boolean} whether the given node is a chai should statement
          */
-        function isChaiShouldCall(node) {
-            let expression = node.expression;
-            if (expression.type === 'ChainExpression') {
-                expression = expression.expression
+        function isChaiShouldCall(expressionNode) {
+            if (expressionNode.type === 'ChainExpression') {
+                expressionNode = expressionNode.expression
             }
-            if (expression.type !== 'MemberExpression') {
+            if (expressionNode.type !== 'MemberExpression') {
                 return false;
             }
 
-            return Boolean(findShouldCall(expression.object));
+            return Boolean(findShouldCall(expressionNode.object));
         }
 
         /**
@@ -280,13 +279,21 @@ module.exports = {
             return null;
         }
 
+        /**
+         * Determines whether or not a given node is a chai call.
+         * @param {ASTNode} expressionNode - expression node
+         * @returns {boolean} whether the given node is a chai call
+         */
+        function isChaiCall(expressionNode) {
+            return isChaiExpectCall(expressionNode) || isChaiShouldCall(expressionNode);
+        }
+
         return {
             ExpressionStatement: function(node) {
                 if (Checker.isDisallowed(node.expression)
                     && !isParserDirective(node)
                     && !(ignoreDirectives && isDirective(node))
-                    && !isChaiExpectCall(node)
-                    && !isChaiShouldCall(node)
+                    && !isChaiCall(node.expression)
                 ) {
                     context.report({node, messageId: "unusedExpression"});
                 }

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -264,7 +264,9 @@ ruleTester.run("no-unused-expressions", rule, {
             code: "foo?.bar?.expect.to.be.true;",
             languageOptions: { ecmaVersion: 11 },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
-        }
+        },
+        { code: "a && expect(foo).to.be.true;",  errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]},
+        { code: "a ? foo.should.be.true : foo.should.be.false;", errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }] },
     ]
 });
 

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -133,6 +133,12 @@ ruleTester.run("no-unused-expressions", rule, {
             code: "expect(foo?.bar).should.be.true;",
             languageOptions: { ecmaVersion: 11 }
         },
+        { code: "a && expect(foo).to.be.true;", options: [{ allowShortCircuit: true }] },
+        { code: "a && foo.should.be.true;", options: [{ allowShortCircuit: true }] },
+        { code: "a ? expect(foo).to.be.true : expect(foo).to.be.false", options: [{ allowTernary: true }] },
+        { code: "a ? foo.should.be.true : foo.should.be.false", options: [{ allowTernary: true }] },
+        { code: "a ? expect(foo).to.be.true || (c = d) : expect(foo).to.be.false", options: [{ allowShortCircuit: true, allowTernary: true }] },
+        { code: "a ? foo.should.be.true || (c = d) : foo.should.be.false", options: [{ allowShortCircuit: true, allowTernary: true }] },
     ],
     invalid: [
         { code: "0", errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }] },


### PR DESCRIPTION
The changes provide a fix for issue #49. It makes sure that chai assertions within ternaries and short circuit expressions are allowed when the options to allow these are set on the rule